### PR TITLE
Remove twitter:domain

### DIFF
--- a/app/server/app.js
+++ b/app/server/app.js
@@ -18,7 +18,6 @@ upstreamQuintypeRoutes(app, { forwardAmp: true });
 
 const STATIC_TAGS = {
   "twitter:site": "Quintype",
-  "twitter:domain": "quintype.com",
   "twitter:app:name:ipad": undefined,
   "twitter:app:name:googleplay": undefined,
   "twitter:app:id:googleplay": undefined,


### PR DESCRIPTION
I think this markup is deprecated, its not to be seen anywhere here https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup