### PR TITLE
Remove duplicate <title>

### DIFF
--- a/views/pages/layout.ejs
+++ b/views/pages/layout.ejs
@@ -1,13 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= title %></title>
+    <%- metaTags -%>
     <link href="/manifest.json" rel="manifest">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <meta content="yes" name="apple-mobile-web-app-capable">
     <meta content="black" name="apple-mobile-web-app-status-bar-style">
     <meta content="Sample Application" name="apple-mobile-web-app-title">
-    <%- metaTags -%>
     <%# load any CSS fonts just below this, curl -vH "User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0" 'https://fonts.googleapis.com/css?family=Font:400,600,700|Another:400' | curl -X POST -s --data-urlencode 'input@-' https://cssminifier.com/raw %>
     <style>
       <%- cssContent %>


### PR DESCRIPTION
The title html tag is also being set by the SEO package. We want that to be the source of truth. 

A consequence of removing this is - existing apps forked from malibu, need to ensure that all their existing pages are calling the SEO package properly and setting the title through it. 