### PR TITLE
Remove the common title from malibu

### DIFF
--- a/app/server/load-data.js
+++ b/app/server/load-data.js
@@ -56,8 +56,7 @@ export function loadData(pageType, params, config, client, { host, next }) {
       data: Object.assign({}, data, {
         navigationMenu: getNavigationMenuArray(config.layout.menu, config.sections)
       }),
-      config: pick(config.asJson(), WHITELIST_CONFIG_KEYS),
-      title: data.title ? `${data.title} - Sample Application` : `Sample Application`
+      config: pick(config.asJson(), WHITELIST_CONFIG_KEYS)
     };
   });
 }


### PR DESCRIPTION
Removing the common title, since the node SEO package should take care of it, this PR was created because while using custom tags in SEO, this title was overridden on the client side