### PR TITLE
fix: update the package version of quintype-node-components to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@quintype/backend": "^1.23.2",
-    "@quintype/components": "^2.23.0-youtube-render.3",
+    "@quintype/components": "^2.25.3",
     "@quintype/framework": "^4.5.4",
     "@quintype/seo": "^1.38.25",
     "fontfaceobserver": "^2.1.0",


### PR DESCRIPTION
# Description

update the quintype-node-components to the latest version

Fixes # (issue-reference) https://github.com/quintype/ace-planning/issues/189


## Type of change

- [x] Library update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Update the package version of quintype-node-components and tested one scenario



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
