### PR TITLE
Remove ga/gtm/onesignal-id

### DIFF
--- a/config/publisher.yml
+++ b/config/publisher.yml
@@ -10,9 +10,9 @@ domain_mapping:
 
 publisher:
   google_tag_manager:
-    id: "GTM-TP6JMSJ"
+    id: "gtm-id"
   google_analytics:
-    id: "UA-139937241-1"
+    id: "ga-id"
   breaking_news:
     is_enable: true
     interval: 120
@@ -20,6 +20,6 @@ publisher:
     open_in_new_tab: false
     pages: [home-page, section-page, tag-page, search-page, story-page, catalog-page, static-page, form-page]
   onesignal:
-    safari_web_id: "web.onesignal.auto.37a647a2-1bdc-46a8-a505-4f4cc6400a46"
+    safari_web_id: "safari-web-id"
     is_enable: true
   enableLogin: true


### PR DESCRIPTION
# Description

This ticket handles the removal of ga/gtm/one signal ids present in publisher yml. The related features will not work locally, please use the relevant ids from the config whenever required.

Fixes https://github.com/quintype/ace-planning/issues/207

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
