### PR TITLE
fix(toggle for enabling GA GTM)

### DIFF
--- a/app/server/handlers/render-layout.js
+++ b/app/server/handlers/render-layout.js
@@ -16,7 +16,9 @@ const getConfig = state => {
   // get onesignal config
   return {
     gtmId: get(state, ["qt", "config", "publisher-attributes", "google_tag_manager", "id"], ""),
+    isGtmEnable: get(state, ["qt", "config", "publisher-attributes", "google_tag_manager", "is_enable"], false),
     gaId: get(state, ["qt", "config", "publisher-attributes", "google_analytics", "id"], ""),
+    isGaEnable: get(state, ["qt", "config", "publisher-attributes", "google_analytics", "is_enable"], false),
     cdnImage: get(state, ["qt", "config", "cdn-image"], ""),
     oneSignalSafariId: get(state, ["qt", "config", "publisher-attributes", "onesignal", "safari_web_id"], null),
     isOnesignalEnable: get(state, ["qt", "config", "publisher-attributes", "onesignal", "is_enable"], false),
@@ -26,9 +28,16 @@ const getConfig = state => {
 
 export function renderLayout(res, params) {
   const chunk = params.shell ? null : allChunks[getChunkName(params.pageType)];
-  const { gtmId, gaId, cdnImage, oneSignalSafariId, isOnesignalEnable, oneSignalAppId } = getConfig(
-    params.store.getState()
-  );
+  const {
+    gtmId,
+    gaId,
+    cdnImage,
+    oneSignalSafariId,
+    isOnesignalEnable,
+    oneSignalAppId,
+    isGtmEnable,
+    isGaEnable
+  } = getConfig(params.store.getState());
   res.render(
     "pages/layout",
     Object.assign(
@@ -57,7 +66,9 @@ export function renderLayout(res, params) {
         serialize,
         oneSignalAppId,
         oneSignalSafariId,
-        isOnesignalEnable
+        isOnesignalEnable,
+        isGtmEnable,
+        isGaEnable
       },
       params
     )

--- a/config/publisher.yml
+++ b/config/publisher.yml
@@ -10,10 +10,10 @@ domain_mapping:
 
 publisher:
   google_tag_manager:
-    id: "GTM-M2JPDF4"
+    id: "gtm-id"
     is_enable: true
   google_analytics:
-    id: "UA-139937241-1"
+    id: "ga-id"
     is_enable: true
   breaking_news:
     is_enable: true

--- a/config/publisher.yml
+++ b/config/publisher.yml
@@ -10,9 +10,11 @@ domain_mapping:
 
 publisher:
   google_tag_manager:
-    id: "gtm-id"
+    id: "GTM-M2JPDF4"
+    is_enable: true
   google_analytics:
-    id: "ga-id"
+    id: "UA-139937241-1"
+    is_enable: true
   breaking_news:
     is_enable: true
     interval: 120

--- a/views/pages/layout.ejs
+++ b/views/pages/layout.ejs
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <%- include ./partials/gtm -%>
-    <%- include ./partials/ga -%>
+    <% if (isGtmEnable) { %>
+      <%- include ./partials/gtm -%>
+    <% } %>
+    <% if (isGaEnable) { %>
+      <%- include ./partials/ga -%>
+    <% } %>
     <%- metaTags -%>
     <link href="/manifest.json" rel="manifest">
     <meta name="viewport" content="width=device-width,height=device-height,initial-scale=1.0,maximum-scale=5.0,minimum-scale=1.0">
@@ -46,7 +50,9 @@
   </head>
 
   <body>
-    <%- include ./partials/noscriptgtm -%>
+    <% if (isGtmEnable) { %>
+      <%- include ./partials/noscriptgtm -%>
+    <% } %>
     <div class="container">
       <header id="header"><%- navbar %></header>
       <div id='breaking-news-container'><%- breakingNews -%></div>


### PR DESCRIPTION
GA and GTM should work according to the toggle key `is_enable` which is  configured in BK.
https://github.com/quintype/ace-planning/issues/212

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Make the toggle ` is_enable: true` from BK and make sure GA and GTM working as expected
```
google_tag_manager:
    id: "gtm-id"
    is_enable: true
```
``` 
 google_analytics:
    id: "ga-id"
    is_enable: true
```
Make the toggle ` is_enable: false` from BK and make sure there is no script associated with GA GTM  in page source.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
