### PR TITLE
Fix: Home and story pages preview

### DIFF
--- a/app/isomorphic/components/pages/homepage-preview.js
+++ b/app/isomorphic/components/pages/homepage-preview.js
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from "react";
+import { HomePage } from "./home.js";
+import { replaceAllStoriesInCollection } from "@quintype/components";
+import { object } from "prop-types";
+
+const HomePagePreview = (props) => {
+  const [started, setStarted] = useState(false);
+  const [data, setData] = useState(props.data);
+
+  const collectStoryData = () => {
+    global.addEventListener("message", (event) => {
+      if (event.data.story) {
+        setStarted(true);
+        const storyData = Object.assign({}, data, {
+          collection: props.data.collection
+            ? replaceAllStoriesInCollection(props.data.collection, event.data.story)
+            : null,
+        });
+        setData(storyData);
+      }
+    });
+  };
+
+  useEffect(() => {
+    collectStoryData();
+  }, []);
+
+  if (!started) return <div />;
+  return <HomePage data={data} />;
+};
+
+HomePagePreview.propTypes = {
+  data: object,
+};
+
+export { HomePagePreview };

--- a/app/isomorphic/components/pages/story.js
+++ b/app/isomorphic/components/pages/story.js
@@ -3,7 +3,8 @@
 import React from "react";
 import { InfiniteStoryBase, WithPreview } from "@quintype/components";
 import { BlankStory } from "../story-templates/blank";
-import { number, object, shape, any } from "prop-types";
+import { number, object, shape, bool, any } from "prop-types";
+import get from "lodash/get";
 
 function StoryPageBase({ index, story, otherProp }) {
   // Can switch to a different template based story-template, or only show a spoiler if index > 0
@@ -31,10 +32,22 @@ function storyPageLoadItems(pageNumber) {
 }
 
 export function StoryPage(props) {
+  const story = get(props, ["data", "story"], get(props, ["story"], null)) || null;
+
+  if (!story) {
+    return null;
+  }
+
+  const renderSingleStoryComponent = <StoryPageBase index={0} story={story} />;
+
+  if (props.isPreview) {
+    return renderSingleStoryComponent;
+  }
+
   return (
     <InfiniteStoryBase
       {...props}
-      render={StoryPageBase}
+      render={(storyProps) => <StoryPageBase {...storyProps} />}
       loadItems={storyPageLoadItems}
       onInitialItemFocus={item =>
         app.registerPageView({ pageType: "story-page", data: { story: item.story } }, `/${item.story.slug}`)
@@ -46,7 +59,8 @@ export function StoryPage(props) {
 
 StoryPage.propTypes = {
   data: shape({
-    story: object
+    story: object,
+    isPreview: bool,
   })
 };
 

--- a/app/isomorphic/components/pages/storypage-preview.js
+++ b/app/isomorphic/components/pages/storypage-preview.js
@@ -1,0 +1,27 @@
+import React, { useState, useEffect } from "react";
+import { StoryPage } from "./story";
+import { object } from "prop-types";
+
+const StoryPagePreview = (props) => {
+  const [data, setData] = useState(null);
+
+  const collectStoryData = () => {
+    global.addEventListener("message", (event) => {
+      if (event.data.story) {
+        setData(event.data);
+      }
+    });
+  };
+
+  useEffect(() => {
+    collectStoryData();
+  }, []);
+
+  return <StoryPage data={data} config={props.config} isPreview={true} />;
+};
+
+StoryPagePreview.propTypes = {
+  config: object,
+};
+
+export { StoryPagePreview };

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link, ResponsiveImage } from "@quintype/components";
-import { shape, string, object, integer, arrayOf } from "prop-types";
+import { shape, string, object, number, arrayOf } from "prop-types";
 import "./story-grid.m.css";
 
 function StoryGridStoryItem(props) {
@@ -36,7 +36,7 @@ const storyPropType = shape({
 
 StoryGridStoryItem.propTypes = {
   story: storyPropType,
-  position: integer
+  position: number
 };
 
 export function StoryGrid({ stories = [] }) {

--- a/app/server/data-loaders/home-page-data.js
+++ b/app/server/data-loaders/home-page-data.js
@@ -5,12 +5,12 @@ import { getStoryLimits } from "../../isomorphic/components/get-collection-templ
 export async function loadHomePageData(client, config, slug) {
   const collection = await Collection.getCollectionBySlug(
     client,
-    slug,
+    slug || "home",
     { "item-type": "collection" },
     { depth: 1, storyLimits: getStoryLimits() }
   );
   return {
-    collection: collection.asJson(),
-    cacheKeys: collection.cacheKeys(config["publisher-id"])
+    collection: collection ? collection.asJson() : null,
+    cacheKeys: collection ? collection.cacheKeys(config["publisher-id"]) : null
   };
 }


### PR DESCRIPTION
# Description

The Home page preview and Story page preview are not working.
The home page preview threw 500 error and story page preview showed a blanked page. 

Fixes # (issue-reference)

Added a check for empty collection in home page preview code and fixed the props validation errors on story page. 

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)
[Preview docs](https://developers.quintype.com/malibu/tutorial/preview.html)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Open Home page preview and it show all the data. It shouldn't throw any errors or blank page. 
- [ ] Open Story page preview and it show all the data. It shouldn't throw any errors or blank page. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
