### PR TITLE
support Nested collection items limit

### DIFF
--- a/tutorial/adding-default-limit-to-collections.md
+++ b/tutorial/adding-default-limit-to-collections.md
@@ -18,12 +18,14 @@ This tutorial is for setting the default collection items limit. If there are no
 
 ```javascript
 ...
+import { getStoryLimits } from "../../isomorphic/components/get-collection-template";
+
 export async function loadHomePageData(client, config, slug) {
   const collection = await Collection.getCollectionBySlug(
     client,
     slug,
     { "item-type": "collection" },
-    { depth: 2, storyLimits: { FourColGrid: 8 , defaultTemplate: 6 }, defaultNestedLimit: 4  }
+    { depth: 2, storyLimits: getStoryLimits(), defaultNestedLimit: 4  }
   );
   ...
 }

--- a/tutorial/support-nested-collection-limit.md
+++ b/tutorial/support-nested-collection-limit.md
@@ -9,37 +9,36 @@ nav_order: 17
 *This tutorial was contributed by [Athira](https://twitter.com/AthiraMRaju) and [Harshith](ttps://www.linkedin.com/in/harshith-raj-092ba4176)*
 
 This tutorial is for setting the nested collection items limit.
+
 ## Rationale
 
-We noticed that */route-data.json* was massive for many publishers (publishers using collection of collection in home/collection page). After debugging, we found that the vast majority of this data is stories that were not needed for the render of the home/collection page. Thus, we wanted to introduce a way to declaratively specify how many stories are loaded by each nested collection.
+We noticed that */route-data.json* was massive for many publishers (publishers using nested collection in home or collection page). The vast majority of this data is stories that were not needed for the render of the home or collection page. Thus, we wanted to introduce a way to declaratively specify how many stories are loaded by each nested collection.
 
-The `nestedCollectionLimit` is the number of stories or collection to fetch from each nested collection. 
-Eg:
+The `nestedCollectionLimit` is the number of stories or collection to fetch from each nested collection. Example:
 - Home `(Level 1)`
-  - Sports Row `(Level 2)` `(Template- FourColGrid)`
+  - Sports Row `(Level 2, Template - FourColGrid)`
     - Cricket `(Level 3, Type - collection)`
     - Football `(Level 3, Type - collection)`
     - Tennis `(Level 3, Type - collection)`
 
-In the above example with `nestedCollectionLimit: {FourColGrid: [2, 3, 4]}`. The `Cricket` collection will fetch `2`  items, `Football` will fetch `3` items and `Tennis` will fetch `4` items respectively. (default: `defaultNestedLimit` || `40`)
+In the above example with `nestedCollectionLimit: {FourColGrid: [2, 3, 4]}`, the `Cricket` collection will fetch `2`  items, `Football` will fetch `3` items and `Tennis` will fetch `4` items respectively. (default: `defaultNestedLimit` || `40`)
 
-
-Note: If `FourColGrid` is a collection of collection and stories pass `null` for the respective position of the story.
-Eg:
+Note: If `FourColGrid` is a collection having collections and stories, pass `null` for the respective position of the story.
+Example:
 - Home `(Level 1)`
-  - Sports Row `(Level 2)` `(Template- FourColGrid)`
+  - Sports Row `(Level 2, Template- FourColGrid)`
     - Cricket `(Level 3, Type - collection)`
     - Story `(Level 3, Type - story)`
     - Football `(Level 3, Type - collection)`
     - Tennis `(Level 3, Type - collection)`
 
-In this case pass `nestedCollectionLimit: {FourColGrid: [2, null, 3, 4]}`.
+In this case, pass `nestedCollectionLimit: {FourColGrid: [2, null, 3, 4]}`.
 
 ## Steps to implement
 
-* First ensure that  *@quintype/components* and *@quintype/framework* are at the latest version
+To enable this feature the *@quintype/components* library needs to be updated to `v2.28.0` and *@quintype/framework* to `v4.13.8`.
 
-* Add the following to *app/isomorphic/components/get-collection-template.js*
+* Add the following to *app/isomorphic/components/get-collection-template.js*:
 
 ```javascript
 import templates from "./collection-templates";
@@ -53,10 +52,19 @@ const collectionLimits = Object.entries(templates).reduce(
 export function getNestedCollectionLimit() {
   return collectionLimits;
 }
+```
+  
+* Add the number of nested collection items to each component. For example, in *app/isomorphic/components/collection-templates/four-col-grid/index.js*, add the following:
 
+```javascript
+function FourColGrid(props) {
+...
+}
+...
+FourColGrid.nestedCollectionLimit = [4, 4, 2];
 ```
 
-* Pass `nestedCollectionLimit` key with required nested collection items limit to `getCollectionBySlug` as shown below.
+* Pass `nestedCollectionLimit: getNestedCollectionLimit()` as shown below.
 
 ```javascript
 ...
@@ -71,19 +79,9 @@ export async function loadHomePageData(client, config, slug) {
   );
   ...
 }
-```
+``` 
 
-* Finally, add the number of nested collection items to each component. For example, in *app/isomorphic/components/collection-templates/four-col-grid/index.js*, add the following
-
-```javascript
-function FourColGrid(props) {
-...
-}
-...
-FourColGrid.nestedCollectionLimit = [4, 4, 2];
-```
-
-* In case you are wrapping components in a function, such as *wrapEager*, then add the following to the relevant function (in this case in *app/isomorphic/components/get-collection-template.js*)
+* In case you are wrapping components with *wrapEager* then add the following inside the function. For example, in *app/isomorphic/components/collection-templates/index.js*
 
 ```javascript
 function wrapEager(f) {

--- a/tutorial/support-nested-collection-limit.md
+++ b/tutorial/support-nested-collection-limit.md
@@ -1,0 +1,37 @@
+---
+title: Support Nested Collection Items Limit
+parent: Malibu Tutorial
+nav_order: 17
+---
+
+# {{page.title}}
+
+*This tutorial was contributed by [Athira](https://twitter.com/AthiraMRaju) and [Harshith](ttps://www.linkedin.com/in/harshith-raj-092ba4176)*
+
+This tutorial is for setting the nested collection items limit. The `nestedCollectionLimit` is the number of stories or collection to fetch from each nested collection. 
+Eg:
+- Home `(Level 1)`
+  - Sports Row `(Level 2)` `(Template- FourColGrid)`
+    - Cricket `(Level 3)`
+    - Football `(Level 3)`
+    - Tennis `(Level 3)`
+
+In the above example with `nestedCollectionLimit: {FourColGrid: [2, 3, 4]}`, The `Cricket` collection will fetch `2`  items, `Football` will fetch `5` items and `Tennis` will fetch `4` items respectively. (default: `defaultNestedLimit` || `40`)
+
+## Steps to implement
+
+* First ensure that *@quintype/framework* is at the latest version
+* Pass `nestedCollectionLimit` key with required nested collection items limit to `getCollectionBySlug` as shown below.
+
+```javascript
+...
+export async function loadHomePageData(client, config, slug) {
+  const collection = await Collection.getCollectionBySlug(
+    client,
+    slug,
+    { "item-type": "collection" },
+    { depth: 2, storyLimits: { FourColGrid: 8 }, defaultNestedLimit: 4 , nestedCollectionLimit: {FourColGrid: [2, 3, 4]}}
+  );
+  ...
+}
+```

--- a/tutorial/support-nested-collection-limit.md
+++ b/tutorial/support-nested-collection-limit.md
@@ -8,7 +8,13 @@ nav_order: 17
 
 *This tutorial was contributed by [Athira](https://twitter.com/AthiraMRaju) and [Harshith](ttps://www.linkedin.com/in/harshith-raj-092ba4176)*
 
-This tutorial is for setting the nested collection items limit. The `nestedCollectionLimit` is the number of stories or collection to fetch from each nested collection. 
+This tutorial is for setting the nested collection items limit.
+## Rationale
+
+We noticed that */route-data.json* was massive for many publishers (publishers using collection of collection in home/collection page). After debugging, we found that the vast majority of this data is stories that were not needed for the render of the home/collection page. Thus, we wanted to introduce a way to declaratively specify how many stories are loaded by each nested collection.
+
+The `nestedCollectionLimit` is the number of stories or collection to fetch from each nested collection. 
+
 Eg:
 - Home `(Level 1)`
   - Sports Row `(Level 2)` `(Template- FourColGrid)`
@@ -20,17 +26,37 @@ In the above example with `nestedCollectionLimit: {FourColGrid: [2, 3, 4]}`, The
 
 ## Steps to implement
 
-* First ensure that *@quintype/framework* is at the latest version
+* First Ensure that  *@quintype/components* and *@quintype/framework* are at the latest version
+
+* Add the following to *app/isomorphic/components/get-collection-template.js*
+
+```javascript
+import templates from "./collection-templates";
+ ...
+
+const collectionLimits = Object.entries(templates).reduce(
+  (acc, [key, value]) => Object.assign(acc, { [key]: value.nestedCollectionLimit }),
+  {}
+);
+
+export function getNestedCollectionLimit() {
+  return collectionLimits;
+}
+
+```
+
 * Pass `nestedCollectionLimit` key with required nested collection items limit to `getCollectionBySlug` as shown below.
 
 ```javascript
 ...
+import { getStoryLimits, getNestedCollectionLimit } from "../../isomorphic/components/get-collection-template";
+
 export async function loadHomePageData(client, config, slug) {
   const collection = await Collection.getCollectionBySlug(
     client,
     slug,
     { "item-type": "collection" },
-    { depth: 2, storyLimits: { FourColGrid: 8 }, defaultNestedLimit: 4 , nestedCollectionLimit: {FourColGrid: [2, 3, 4]}}
+    { depth: 2, storyLimits: getStoryLimits() , defaultNestedLimit: 4 , nestedCollectionLimit: getNestedCollectionLimit()}
   );
   ...
 }

--- a/tutorial/support-nested-collection-limit.md
+++ b/tutorial/support-nested-collection-limit.md
@@ -14,15 +14,26 @@ This tutorial is for setting the nested collection items limit.
 We noticed that */route-data.json* was massive for many publishers (publishers using collection of collection in home/collection page). After debugging, we found that the vast majority of this data is stories that were not needed for the render of the home/collection page. Thus, we wanted to introduce a way to declaratively specify how many stories are loaded by each nested collection.
 
 The `nestedCollectionLimit` is the number of stories or collection to fetch from each nested collection. 
-
 Eg:
 - Home `(Level 1)`
   - Sports Row `(Level 2)` `(Template- FourColGrid)`
-    - Cricket `(Level 3)`
-    - Football `(Level 3)`
-    - Tennis `(Level 3)`
+    - Cricket `(Level 3, Type - collection)`
+    - Football `(Level 3, Type - collection)`
+    - Tennis `(Level 3, Type - collection)`
 
-In the above example with `nestedCollectionLimit: {FourColGrid: [2, 3, 4]}`, The `Cricket` collection will fetch `2`  items, `Football` will fetch `5` items and `Tennis` will fetch `4` items respectively. (default: `defaultNestedLimit` || `40`)
+In the above example with `nestedCollectionLimit: {FourColGrid: [2, 3, 4]}`. The `Cricket` collection will fetch `2`  items, `Football` will fetch `3` items and `Tennis` will fetch `4` items respectively. (default: `defaultNestedLimit` || `40`)
+
+
+Note: If `FourColGrid` is a collection of collection and stories pass `null` for the respective position of the story.
+Eg:
+- Home `(Level 1)`
+  - Sports Row `(Level 2)` `(Template- FourColGrid)`
+    - Cricket `(Level 3, Type - collection)`
+    - Story `(Level 3, Type - story)`
+    - Football `(Level 3, Type - collection)`
+    - Tennis `(Level 3, Type - collection)`
+
+In this case pass `nestedCollectionLimit: {FourColGrid: [2, null, 3, 4]}`.
 
 ## Steps to implement
 

--- a/tutorial/support-nested-collection-limit.md
+++ b/tutorial/support-nested-collection-limit.md
@@ -37,7 +37,7 @@ In this case pass `nestedCollectionLimit: {FourColGrid: [2, null, 3, 4]}`.
 
 ## Steps to implement
 
-* First Ensure that  *@quintype/components* and *@quintype/framework* are at the latest version
+* First ensure that  *@quintype/components* and *@quintype/framework* are at the latest version
 
 * Add the following to *app/isomorphic/components/get-collection-template.js*
 
@@ -70,5 +70,31 @@ export async function loadHomePageData(client, config, slug) {
     { depth: 2, storyLimits: getStoryLimits() , defaultNestedLimit: 4 , nestedCollectionLimit: getNestedCollectionLimit()}
   );
   ...
+}
+```
+
+* Finally, add the number of nested collection items to each component. For example, in *app/isomorphic/components/collection-templates/four-col-grid/index.js*, add the following
+
+```javascript
+function FourColGrid(props) {
+...
+}
+...
+FourColGrid.nestedCollectionLimit = [4, 4, 2];
+```
+
+* In case you are wrapping components in a function, such as *wrapEager*, then add the following to the relevant function (in this case in *app/isomorphic/components/get-collection-template.js*)
+
+```javascript
+function wrapEager(f) {
+  const wrappedComponent = function WrapEager(props) {
+    ...
+  };
+
+  if (f.nestedCollectionLimit) {
+    wrappedComponent.nestedCollectionLimit = f.nestedCollectionLimit;
+  }
+
+  return wrappedComponent;
 }
 ```


### PR DESCRIPTION
Set story limit in nested collections
https://github.com/quintype/ace-planning/issues/18

Dependencies   - https://github.com/quintype/malibu/pull/736

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
