### PR TITLE
Add few links and minor typo corrections

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,24 +6,26 @@ nav_order: 1
 
 A Javascript framework for building apps with Quintype.
 
-The goal of malibu is to make building content sites trivial. Bring your look and feel, and Malibu will handle the rest.
+The goal of Malibu is to make building content sites trivial. Bring your look and feel, and Malibu will handle the rest.
 
-You might want to check out the following topics, before jumping right in to the [tutorial]({{"/tutorial" | absolute_url}})
+You might want to check out the following topics, before jumping right into the [tutorial]({{"/tutorial" | absolute_url}}).
 
 * [Common Terminology]({{"/terminology" | absolute_url}})
 * [Moving Parts]({{"/moving-parts" | absolute_url}})
 * [Why Malibu?]({{"/why-malibu" | absolute_url}})
+* [Why Malibu Advanced ?]({{"#" | absolute_url}})
 * [Getting Started]({{"/tutorial/getting-started" | absolute_url}})
 
-We also have a few more advanced topics
+We also have a few more advanced topics:
 * [How does Isomorphic Rendering Work?]({{"/isomorphic-rendering" | absolute_url}})
 * [Swagger Documentation](https://developers.quintype.com/swagger/)
+* [Performance Improvements](#)
 
-Malibu is build on top of the following libraries from quintype. You can find links to the relevant JSDocs below.
-* [@quintype/framework](https://developers.quintype.com/quintype-node-framework) - The framework that powers malibu
+Malibu is built on top of the following libraries from quintype. You can find links to the relevant JSDocs below.
+* [@quintype/framework](https://developers.quintype.com/quintype-node-framework) - The framework that powers Malibu
 * [@quintype/components](https://developers.quintype.com/quintype-node-components) - Viewless components to handle common logic
-* [@quintype/seo](https://developers.quintype.com/quintype-node-seo) - SEO plugin for malibu
+* [@quintype/seo](https://developers.quintype.com/quintype-node-seo) - SEO plugin for Malibu
 * [@quintype/backend](https://developers.quintype.com/quintype-node-backend) - Node API client
 * [@quintype/build](https://developers.quintype.com/quintype-node-build) - Build Scripts for dockerizing your build
 * [@quintype/amp](https://developers.quintype.com/quintype-amp) - Library powering AMP pages
-* [@quintype/bridgekeeper-js](https://developers.quintype.com/bridgekeeper-js) - Login/Register apis powered by bridgekeeper
+* [@quintype/bridgekeeper-js](https://developers.quintype.com/bridgekeeper-js) - Login/Register apis powered by [Bridgekeeper](https://developers.quintype.com/bridgekeeper)


### PR DESCRIPTION
# Description

This includes changes on this [page](https://developers.quintype.com/malibu/).
This includes the addition of Malibu-advanced/Bridgekeeper links and placeholder for perf improvements.
This includes very minor typo changes as well.