### PR TITLE
Fix: Enable hot reload for prerender function

### DIFF
--- a/app/client/app.js
+++ b/app/client/app.js
@@ -14,7 +14,10 @@ const opts = {
 
 function enableHotReload(store) {
   if (process.env.NODE_ENV === "development" && module.hot) {
-    module.hot.accept("./render", () => renderApplication(store));
+    module.hot.accept("./render", () => {
+      renderApplication(store);
+      preRenderApplication(store);
+    });
   }
 }
 


### PR DESCRIPTION
# Description

The hot reload was working only for `renderApplication` function but not working for `preRenderApplication`. This fix enables the hot reload for `preRenderApplication` as well.

Fixes: https://github.com/quintype/ace-planning/issues/408

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


