### PR TITLE
feat Progressive image loading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ jobs:
       - checkout
       - run: |
           export LHCI_SITES="[\"https://malibu-perf.quintype.io/?uptime\"]"
+          export LHCI_SCORE_BENCHMARK=0.9
           npx @lhci/cli@0.6.x autorun
 
 

--- a/app/isomorphic/components/atoms/card-image/card-image.m.css
+++ b/app/isomorphic/components/atoms/card-image/card-image.m.css
@@ -3,5 +3,5 @@
 }
 
 .placeholder {
-  background-color: lightgray;
+  background-color: var(--grey-light);
 }

--- a/app/isomorphic/components/atoms/card-image/card-image.m.css
+++ b/app/isomorphic/components/atoms/card-image/card-image.m.css
@@ -1,4 +1,4 @@
-.story-grid-item-image {
+.card-image {
   width: 100%;
 }
 

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { get } from "lodash";
+import get from "lodash/get";
 import { ResponsiveImage } from "@quintype/components";
 import { shape, string, object, bool } from "prop-types";
 import { useSelector } from "react-redux";
@@ -20,10 +20,9 @@ export const CardImage = ({ story, isInitRow, pageType }) => {
     if (isInitRow && progressiveImageConfig.is_enable) {
       // if we need progressive loading for the images in the page, isInitRow condition can be removed
       const timer = setTimeout(() => {
+        clearTimeout(timer);
         setPerfObj(progressiveImageConfig.subsequent_load);
       }, progressiveImageConfig.transition_timeout || 2500);
-
-      return () => clearTimeout(timer);
     }
   }, []);
 

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -11,14 +11,13 @@ export const CardImage = ({ story, isInitRow, pageType }) => {
     get(state, ["qt", "config", "publisher-attributes", "progressive_image"], {})
   );
 
-  const imagePerfObj = progressiveImageConfig.is_enable
-    ? progressiveImageConfig.initial_load
-    : { size: "25vw", blur: 0 };
+  const imagePerfObj =
+    progressiveImageConfig.is_enable && isInitRow ? progressiveImageConfig.initial_load : { size: "25vw", blur: 0 };
   const [perfObj, setPerfObj] = useState(imagePerfObj);
   const customStyleName = pageType !== "story-page" && !story["hero-image-s3-key"] ? "placeholder" : "";
 
   useEffect(() => {
-    if (isInitRow) {
+    if (isInitRow && progressiveImageConfig.is_enable) {
       // if we need progressive loading for the images in the page, this condition can be removed
       setTimeout(() => {
         setPerfObj(progressiveImageConfig.subsequent_load);

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -18,10 +18,13 @@ export const CardImage = ({ story, isInitRow, pageType }) => {
 
   useEffect(() => {
     if (isInitRow && progressiveImageConfig.is_enable) {
-      // if we need progressive loading for the images in the page, this condition can be removed
-      setTimeout(() => {
-        setPerfObj(progressiveImageConfig.subsequent_load);
-      }, progressiveImageConfig.transition_timeout || 2500);
+      // if we need progressive loading for the images in the page, isInitRow condition can be removed
+      const timer = () => {
+        setTimeout(() => {
+          setPerfObj(progressiveImageConfig.subsequent_load);
+        }, progressiveImageConfig.transition_timeout || 2500);
+      };
+      return () => clearTimeout(timer);
     }
   }, []);
 

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -4,20 +4,29 @@ import { shape, string, object, bool } from "prop-types";
 
 import "./card-image.m.css";
 
-export const CardImage = ({ story, isInitRow }) => {
+export const CardImage = ({ story, isInitRow, pageType }) => {
   const imagePerfObj = isInitRow ? { size: "3vw", blur: 0 } : { size: "25vw", blur: 0 };
   const [perfObj, setPerfObj] = useState(imagePerfObj);
+  const customStyleName = pageType !== "story-page" && !story["hero-image-s3-key"] ? "placeholder" : "";
+
+  const perfImageTimeout = (size, blur) => {
+    setTimeout(() => {
+      setPerfObj({ size, blur });
+    }, 2500);
+  };
 
   useEffect(() => {
     if (isInitRow) {
-      setTimeout(() => {
-        setPerfObj({ size: "30vw", blur: 0 });
-      }, 2500);
+      if (pageType === "story-page") {
+        perfImageTimeout("50vw", 0);
+      } else {
+        perfImageTimeout("25vw", 0);
+      }
     }
   }, []);
 
   return (
-    <figure className="qt-image-16x9" styleName={`card-image ${!story["hero-image-s3-key"] ? "placeholder" : ""}`}>
+    <figure className="qt-image-16x9" styleName={`card-image ${customStyleName}`}>
       {story["hero-image-s3-key"] && (
         <ResponsiveImage
           slug={story["hero-image-s3-key"]}
@@ -45,5 +54,6 @@ const storyPropType = shape({
 
 CardImage.propTypes = {
   story: storyPropType,
-  isInitRow: bool
+  isInitRow: bool,
+  pageType: string
 };

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -19,6 +19,7 @@ export const CardImage = ({ story, isInitRow, pageType }) => {
 
   useEffect(() => {
     if (isInitRow) {
+      // if we need progressive loading for the images in the page, this condition can be removed
       setTimeout(() => {
         setPerfObj(progressiveImageConfig.subsequent_load);
       }, progressiveImageConfig.transition_timeout || 2500);

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -19,14 +19,11 @@ export const CardImage = ({ story, isInitRow, pageType }) => {
   useEffect(() => {
     if (isInitRow && progressiveImageConfig.is_enable) {
       // if we need progressive loading for the images in the page, isInitRow condition can be removed
-      const timer = () => {
-        setTimeout(() => {
-          setPerfObj(progressiveImageConfig.subsequent_load);
-          clearTimeout(timer);
-        }, progressiveImageConfig.transition_timeout || 2500);
-      };
+      const timer = setTimeout(() => {
+        setPerfObj(progressiveImageConfig.subsequent_load);
+      }, progressiveImageConfig.transition_timeout || 2500);
 
-      timer();
+      return () => clearTimeout(timer);
     }
   }, []);
 
@@ -37,20 +34,28 @@ export const CardImage = ({ story, isInitRow, pageType }) => {
     return perfObj.generic_size;
   };
 
+  const getImage = () => {
+    if (!story["hero-image-s3-key"]) {
+      return null;
+    }
+
+    return (
+      <ResponsiveImage
+        slug={story["hero-image-s3-key"]}
+        metadata={story["hero-image-metadata"]}
+        aspectRatio={[16, 9]}
+        defaultWidth={480}
+        widths={[250, 480, 640]}
+        sizes={getImageSize()}
+        imgParams={{ auto: ["format", "compress"], blur: perfObj.blur }}
+        alt={story.headline || ""}
+      />
+    );
+  };
+
   return (
     <figure className="qt-image-16x9" styleName={`card-image ${customStyleName}`}>
-      {story["hero-image-s3-key"] && (
-        <ResponsiveImage
-          slug={story["hero-image-s3-key"]}
-          metadata={story["hero-image-metadata"]}
-          aspectRatio={[16, 9]}
-          defaultWidth={480}
-          widths={[250, 480, 640]}
-          sizes={getImageSize()}
-          imgParams={{ auto: ["format", "compress"], blur: perfObj.blur }}
-          alt={story.headline || ""}
-        />
-      )}
+      {getImage()}
     </figure>
   );
 };

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from "react";
+import { ResponsiveImage } from "@quintype/components";
+import { shape, string, object, bool } from "prop-types";
+
+import "./card-image.m.css";
+
+export const CardImage = ({ story, isInitRow }) => {
+  const imagePerfObj = isInitRow ? { size: "3vw", blur: 0 } : { size: "25vw", blur: 0 };
+  const [perfObj, setPerfObj] = useState(imagePerfObj);
+
+  useEffect(() => {
+    if (isInitRow) {
+      setTimeout(() => {
+        setPerfObj({ size: "30vw", blur: 0 });
+      }, 2500);
+    }
+  }, []);
+
+  return (
+    <figure className="qt-image-16x9" styleName={`card-image ${!story["hero-image-s3-key"] ? "placeholder" : ""}`}>
+      {story["hero-image-s3-key"] && (
+        <ResponsiveImage
+          slug={story["hero-image-s3-key"]}
+          metadata={story["hero-image-metadata"]}
+          aspectRatio={[16, 9]}
+          defaultWidth={480}
+          widths={[250, 480, 640]}
+          sizes={perfObj.size}
+          imgParams={{ auto: ["format", "compress"], blur: perfObj.blur }}
+          alt={story.headline || ""}
+        />
+      )}
+    </figure>
+  );
+};
+
+const storyPropType = shape({
+  id: string,
+  slug: string,
+  "hero-image-s3-key": string,
+  "hero-image-metadata": object,
+  headline: string,
+  "author-name": string
+});
+
+CardImage.propTypes = {
+  story: storyPropType,
+  isInitRow: bool
+};

--- a/app/isomorphic/components/atoms/card-image/index.js
+++ b/app/isomorphic/components/atoms/card-image/index.js
@@ -22,9 +22,11 @@ export const CardImage = ({ story, isInitRow, pageType }) => {
       const timer = () => {
         setTimeout(() => {
           setPerfObj(progressiveImageConfig.subsequent_load);
+          clearTimeout(timer);
         }, progressiveImageConfig.transition_timeout || 2500);
       };
-      return () => clearTimeout(timer);
+
+      timer();
     }
   }, []);
 

--- a/app/isomorphic/components/collection-templates/four-col-grid/index.js
+++ b/app/isomorphic/components/collection-templates/four-col-grid/index.js
@@ -6,10 +6,11 @@ import { StoryGrid } from "../../story-grid";
 import "./four-col-grid.m.css";
 
 export function FourColGrid({ collection, stories, index }) {
+  const isInitRow = index === 0 || index === 1;
   return (
     <div>
       <h2 styleName="heading">{collection.name}</h2>
-      <StoryGrid stories={stories} rowNumber={index} />
+      <StoryGrid stories={stories} isInitRow={isInitRow} />
     </div>
   );
 }

--- a/app/isomorphic/components/collection-templates/four-col-grid/index.js
+++ b/app/isomorphic/components/collection-templates/four-col-grid/index.js
@@ -1,22 +1,23 @@
 // Implement more logic here
 
 import React from "react";
-import { array, object } from "prop-types";
+import { array, object, number } from "prop-types";
 import { StoryGrid } from "../../story-grid";
 import "./four-col-grid.m.css";
 
-export function FourColGrid({ collection, stories }) {
+export function FourColGrid({ collection, stories, index }) {
   return (
     <div>
       <h2 styleName="heading">{collection.name}</h2>
-      <StoryGrid stories={stories} />
+      <StoryGrid stories={stories} rowNumber={index} />
     </div>
   );
 }
 
 FourColGrid.propTypes = {
   collection: object,
-  stories: array
+  stories: array,
+  index: number
 };
 
 FourColGrid.storyLimit = 8;

--- a/app/isomorphic/components/pages/author-page/index.js
+++ b/app/isomorphic/components/pages/author-page/index.js
@@ -11,7 +11,7 @@ const AuthorPage = props => {
   return (
     <div className="container">
       <h1>{`Author - ${props.data.author.name}`}</h1>
-      <StoryGrid stories={stories} />
+      <StoryGrid stories={stories} isInitRow />
     </div>
   );
 };

--- a/app/isomorphic/components/pages/search.js
+++ b/app/isomorphic/components/pages/search.js
@@ -8,7 +8,7 @@ const SearchPage = props => (
     <h1>
       Search - {props.data.query} ({props.data.total} results)
     </h1>
-    <StoryGrid stories={props.data.stories} />
+    <StoryGrid stories={props.data.stories} isInitRow />
   </div>
 );
 

--- a/app/isomorphic/components/pages/section.js
+++ b/app/isomorphic/components/pages/section.js
@@ -23,7 +23,7 @@ const SectionPage = props => {
   return (
     <div className="container">
       <h1>{pageTitle}</h1>
-      <StoryGrid stories={stories} />
+      <StoryGrid stories={stories} isInitRow />
       <LazyCollection collection={{ items: childCollections }} collectionTemplates={getCollectionTemplate} />
     </div>
   );

--- a/app/isomorphic/components/pages/tag.js
+++ b/app/isomorphic/components/pages/tag.js
@@ -7,7 +7,7 @@ import { StoryGrid } from "../story-grid";
 const TagPage = props => (
   <div className="container">
     <h1>{get(props, "data.tag.name") || "Tag Page"}</h1>
-    <StoryGrid stories={props.data.stories} />
+    <StoryGrid stories={props.data.stories} isInitRow />
   </div>
 );
 

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -1,9 +1,19 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link, ResponsiveImage } from "@quintype/components";
 import { shape, string, object, integer, arrayOf } from "prop-types";
 import "./story-grid.m.css";
 
 function StoryGridStoryItem(props) {
+  const [size, setSize] = useState("10vw");
+  const [blur, setBlur] = useState(10);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setSize("30vw");
+      setBlur(0);
+    }, 2500);
+  }, []);
+
   return (
     <Link href={`/${props.story.slug}`} className="story-grid-item">
       <figure className="qt-image-16x9" styleName="story-grid-item-image">
@@ -13,8 +23,8 @@ function StoryGridStoryItem(props) {
           aspectRatio={[16, 9]}
           defaultWidth={480}
           widths={[250, 480, 640]}
-          sizes="10vw"
-          imgParams={{ auto: ["format", "compress"], blur: 10 }}
+          sizes={size}
+          imgParams={{ auto: ["format", "compress"], blur: blur }}
           alt={props.story.headline || ""}
         />
       </figure>

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -4,29 +4,33 @@ import { shape, string, object, integer, arrayOf } from "prop-types";
 import "./story-grid.m.css";
 
 function StoryGridStoryItem(props) {
-  const [size, setSize] = useState("10vw");
-  const [blur, setBlur] = useState(10);
+  const imagePerfObj = { size: "10vw", blur: 10 };
+  const [perfObj, setPerfObj] = useState(imagePerfObj);
 
   useEffect(() => {
     setTimeout(() => {
-      setSize("30vw");
-      setBlur(0);
+      setPerfObj({ size: "30vw", blur: 0 });
     }, 2500);
   }, []);
 
   return (
     <Link href={`/${props.story.slug}`} className="story-grid-item">
-      <figure className="qt-image-16x9" styleName="story-grid-item-image">
-        <ResponsiveImage
-          slug={props.story["hero-image-s3-key"]}
-          metadata={props.story["hero-image-metadata"]}
-          aspectRatio={[16, 9]}
-          defaultWidth={480}
-          widths={[250, 480, 640]}
-          sizes={size}
-          imgParams={{ auto: ["format", "compress"], blur: blur }}
-          alt={props.story.headline || ""}
-        />
+      <figure
+        className="qt-image-16x9"
+        styleName={`story-grid-item-image ${!props.story["hero-image-s3-key"] ? "placeholder" : ""}`}
+      >
+        {props.story["hero-image-s3-key"] && (
+          <ResponsiveImage
+            slug={props.story["hero-image-s3-key"]}
+            metadata={props.story["hero-image-metadata"]}
+            aspectRatio={[16, 9]}
+            defaultWidth={480}
+            widths={[250, 480, 640]}
+            sizes={perfObj.size}
+            imgParams={{ auto: ["format", "compress"], blur: perfObj.blur }}
+            alt={props.story.headline || ""}
+          />
+        )}
       </figure>
       <h3>{props.story.headline}</h3>
       <span className="story-grid-item-author">{props.story["author-name"]}</span>

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -13,7 +13,7 @@ function StoryGridStoryItem(props) {
           aspectRatio={[16, 9]}
           defaultWidth={480}
           widths={[250, 480, 640]}
-          sizes="5vw"
+          sizes="10vw"
           imgParams={{ auto: ["format", "compress"], blur: 10 }}
           alt={props.story.headline || ""}
         />

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -1,44 +1,16 @@
-import React, { useEffect, useState } from "react";
-import { Link, ResponsiveImage } from "@quintype/components";
+import React from "react";
+import { Link } from "@quintype/components";
 import { shape, string, object, arrayOf, number, bool } from "prop-types";
-import "./story-grid.m.css";
 
-function StoryGridStoryItem(props) {
-  const imagePerfObj = props.isInitRow ? { size: "3vw", blur: 0 } : { size: "25vw", blur: 0 };
-  const [perfObj, setPerfObj] = useState(imagePerfObj);
+import { CardImage } from "./atoms/card-image";
 
-  useEffect(() => {
-    if (props.isInitRow) {
-      setTimeout(() => {
-        setPerfObj({ size: "30vw", blur: 0 });
-      }, 2500);
-    }
-  }, []);
-
-  return (
-    <Link href={`/${props.story.slug}`} className="story-grid-item">
-      <figure
-        className="qt-image-16x9"
-        styleName={`story-grid-item-image ${!props.story["hero-image-s3-key"] ? "placeholder" : ""}`}
-      >
-        {props.story["hero-image-s3-key"] && (
-          <ResponsiveImage
-            slug={props.story["hero-image-s3-key"]}
-            metadata={props.story["hero-image-metadata"]}
-            aspectRatio={[16, 9]}
-            defaultWidth={480}
-            widths={[250, 480, 640]}
-            sizes={perfObj.size}
-            imgParams={{ auto: ["format", "compress"], blur: perfObj.blur }}
-            alt={props.story.headline || ""}
-          />
-        )}
-      </figure>
-      <h3>{props.story.headline}</h3>
-      <span className="story-grid-item-author">{props.story["author-name"]}</span>
-    </Link>
-  );
-}
+const StoryGridStoryItem = props => (
+  <Link href={`/${props.story.slug}`} className="story-grid-item">
+    <CardImage story={props.story} isInitRow={props.isInitRow} />
+    <h3>{props.story.headline}</h3>
+    <span className="story-grid-item-author">{props.story["author-name"]}</span>
+  </Link>
+);
 
 const storyPropType = shape({
   id: string,

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -27,12 +27,10 @@ StoryGridStoryItem.propTypes = {
   isInitRow: bool
 };
 
-export function StoryGrid({ stories = [], rowNumber }) {
+export function StoryGrid({ stories = [], isInitRow }) {
   if (stories.length === 0) {
     return null;
   }
-
-  const isInitRow = rowNumber === 0 || rowNumber === 1;
 
   return (
     <div className="story-grid">
@@ -45,5 +43,5 @@ export function StoryGrid({ stories = [], rowNumber }) {
 
 StoryGrid.propTypes = {
   stories: arrayOf(storyPropType),
-  rowNumber: number
+  isInitRow: bool
 };

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -13,9 +13,8 @@ function StoryGridStoryItem(props) {
           aspectRatio={[16, 9]}
           defaultWidth={480}
           widths={[250, 480, 640]}
-          sizes="( max-width: 500px ) 98vw, ( max-width: 768px ) 48vw, 23vw"
-          imgParams={{ auto: ["format", "compress"] }}
-          eager={props.position < 2 ? "above-fold" : "below-fold"}
+          sizes="25vw"
+          imgParams={{ auto: ["format", "compress"], blur: 100 }}
           alt={props.story.headline || ""}
         />
       </figure>

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -14,7 +14,7 @@ function StoryGridStoryItem(props) {
           defaultWidth={480}
           widths={[250, 480, 640]}
           sizes="5vw"
-          imgParams={{ auto: ["format", "compress"], blur: 100 }}
+          imgParams={{ auto: ["format", "compress"], blur: 10 }}
           alt={props.story.headline || ""}
         />
       </figure>

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -13,7 +13,7 @@ function StoryGridStoryItem(props) {
           aspectRatio={[16, 9]}
           defaultWidth={480}
           widths={[250, 480, 640]}
-          sizes="25vw"
+          sizes="5vw"
           imgParams={{ auto: ["format", "compress"], blur: 100 }}
           alt={props.story.headline || ""}
         />

--- a/app/isomorphic/components/story-grid.js
+++ b/app/isomorphic/components/story-grid.js
@@ -1,16 +1,18 @@
 import React, { useEffect, useState } from "react";
 import { Link, ResponsiveImage } from "@quintype/components";
-import { shape, string, object, integer, arrayOf } from "prop-types";
+import { shape, string, object, arrayOf, number, bool } from "prop-types";
 import "./story-grid.m.css";
 
 function StoryGridStoryItem(props) {
-  const imagePerfObj = { size: "10vw", blur: 10 };
+  const imagePerfObj = props.isInitRow ? { size: "3vw", blur: 0 } : { size: "25vw", blur: 0 };
   const [perfObj, setPerfObj] = useState(imagePerfObj);
 
   useEffect(() => {
-    setTimeout(() => {
-      setPerfObj({ size: "30vw", blur: 0 });
-    }, 2500);
+    if (props.isInitRow) {
+      setTimeout(() => {
+        setPerfObj({ size: "30vw", blur: 0 });
+      }, 2500);
+    }
   }, []);
 
   return (
@@ -49,23 +51,27 @@ const storyPropType = shape({
 
 StoryGridStoryItem.propTypes = {
   story: storyPropType,
-  position: integer
+  position: number,
+  isInitRow: bool
 };
 
-export function StoryGrid({ stories = [] }) {
+export function StoryGrid({ stories = [], rowNumber }) {
   if (stories.length === 0) {
     return null;
   }
 
+  const isInitRow = rowNumber === 0 || rowNumber === 1;
+
   return (
     <div className="story-grid">
       {stories.map((story, index) => (
-        <StoryGridStoryItem story={story} key={`${index}-${story.id}`} position={index} />
+        <StoryGridStoryItem story={story} key={`${index}-${story.id}`} position={index} isInitRow={isInitRow} />
       ))}
     </div>
   );
 }
 
 StoryGrid.propTypes = {
-  stories: arrayOf(storyPropType)
+  stories: arrayOf(storyPropType),
+  rowNumber: number
 };

--- a/app/isomorphic/components/story-grid.m.css
+++ b/app/isomorphic/components/story-grid.m.css
@@ -1,3 +1,7 @@
 .story-grid-item-image {
   width: 100%;
 }
+
+.placeholder {
+  background-color: lightgray;
+}

--- a/app/isomorphic/components/story-templates/blank.js
+++ b/app/isomorphic/components/story-templates/blank.js
@@ -1,7 +1,8 @@
 import React from "react";
 import PT from "prop-types";
 
-import { ResponsiveImage, StoryElement } from "@quintype/components";
+import { StoryElement } from "@quintype/components";
+import { CardImage } from "../atoms/card-image";
 
 function StoryCard(props) {
   return (
@@ -21,16 +22,8 @@ StoryCard.propTypes = {
 function BlankStoryTemplate(props) {
   return (
     <div className="blank-story container">
-      <figure className="blank-story-image qt-image-16x9">
-        <ResponsiveImage
-          slug={props.story["hero-image-s3-key"]}
-          metadata={props.story["hero-image-metadata"]}
-          aspectRatio={[16, 9]}
-          defaultWidth={480}
-          widths={[250, 480, 640]}
-          imgParams={{ auto: ["format", "compress"] }}
-        />
-      </figure>
+      {/* The pagetype can be fetched from redux as well */}
+      <CardImage pageType="story-page" story={props.story} isInitRow />
       <h1>{props.story.headline}</h1>
       <span className="blank-story-author">{props.story["author-name"]}</span>
       {props.story.cards.map(card => (

--- a/config/publisher.yml
+++ b/config/publisher.yml
@@ -23,3 +23,16 @@ publisher:
     open_in_new_tab: false
     pages: [home-page, section-page, tag-page, search-page, story-page, catalog-page, static-page, form-page]
   should_use_collection: true
+  progressive_image:
+    is_enable: true
+    transition_timeout: 2500
+    initial_load:
+      blur: 0
+      generic_size: "3vw"
+      story_page_size: "10vw"
+    subsequent_load:
+      blur: 0
+      generic_size: "25vw"
+      story_page_size: "50vw"
+
+

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,14 +2,31 @@ const url = `https://${process.env.LH_USER}:${process.env.LH_PASSWORD}@lighthous
 const lhciConfig = {
   ci: {
     collect: {
-      url: JSON.parse(process.env.LHCI_SITES),
+      numberOfRuns: 5,
+      additive: false, // Skips clearing of previous collect data
+      headful: false, // Run with a headful Chrome
+      url: JSON.parse(process.env.LHCI_SITES), // A URL to run Lighthouse on
       settings: {
-        emulatedFormFactor: "mobile"
+        emulatedFormFactor: "mobile",
+        throttlingMethod: "devtools"
       }
     },
     assert: {
       assertions: {
-        "categories:performance": ["error", { minScore: 0.9 }]
+        "unused-javascript": "warn",
+        "heading-order": "off", // Heading elements are not in a sequentially-descending order
+        "is-crawlable": "warn",
+        "tap-targets": "warn", // Tap targets are the areas of a web page that users on touch devices can interact with. Buttons, links, and form elements all have tap targets.
+        "uses-responsive-images": "warn",
+        "errors-in-console": "warn", // Browser errors were logged to the console
+        "uses-text-compression": "warn",
+        "uses-optimized-images": "warn",
+        "no-unload-listeners": "off",
+        "no-document-write": "warn", // Avoid `document.write()`
+        "categories:performance": ["error", { minScore: 0.95 }],
+        "image-alt": "warn",
+        "link-name": "warn",
+        "link-text": "warn"
       }
     },
     upload: {

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -23,7 +23,7 @@ const lhciConfig = {
         "uses-optimized-images": "warn",
         "no-unload-listeners": "off",
         "no-document-write": "warn", // Avoid `document.write()`
-        "categories:performance": ["error", { minScore: 0.95 }],
+        "categories:performance": ["error", { minScore: JSON.parse(process.env.LHCI_SCORE_BENCHMARK) || 0.95 }],
         "image-alt": "warn",
         "link-name": "warn",
         "link-text": "warn"

--- a/views/pages/layout.ejs
+++ b/views/pages/layout.ejs
@@ -20,7 +20,8 @@
       window.GUMLET_CONFIG = {
         hosts: [{ current: "<%= cdnImage %>", gumlet: "<%= cdnImage %>" }],
         lazy_load: true,
-        auto_webp: true
+        auto_webp: true,
+        srcset: true
       }
     </script>
     <script src="https://cdn.gumlet.com/gumlet.js/2.0/gumlet.min.js" type="text/javascript" defer="defer"></script>


### PR DESCRIPTION
# Description

we are rendering a smaller size image on the initial load and then loading a higher quality of the image after few seconds. Doing this will improve page performance as we render a smaller size image initially. this size, time to load high quality image and other params are configurable from bk

Fixes: https://github.com/quintype/ace-planning/issues/419

Documentation: will taken in diff pr

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] tested locally and on staging for backend compatibity
- [ ] check the improved scores on page speed insights


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
