### PR TITLE
pass prerenderServiceUrl to enable prerender

### DIFF
--- a/app/server/app.js
+++ b/app/server/app.js
@@ -89,5 +89,6 @@ isomorphicRoutes(app, {
     enableNews: true,
     structuredData: STRUCTURED_DATA
   }),
-  preloadJs: true
+  preloadJs: true,
+  prerenderServiceUrl: "https://prerender.quintype.io"
 });


### PR DESCRIPTION
As part of https://github.com/quintype/ace-planning/issues/429 we are experimenting with removing CF worker and instead using transform rules. For that need to enable prerender on malibu and test, hence this PR