### PR TITLE
docs: generating placeholder documentation

### DIFF
--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -14,7 +14,7 @@ An image placeholder is a background color over the space, on which an actual im
 How Quintype handles image placeholder?
 
 - Wrap `ResponsiveImage` component with `figure` tag.
-- Based on aspect ratio of the image provide `padding-top` to the `figure` tag using styleName/className.
+- Based on aspect ratio of the image, provide `padding-top` for the `figure` tag using styleName/className.
 - Use a generic styleName/className to the `figure` tag to provide required `background- color`.
 
 Eg: 
@@ -47,9 +47,9 @@ Eg:
 }
 ```
 
-If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder from `black knight` `enable_placeholder` which accepts a boolean value.
+If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder, pass `enable_placeholder` from `/app/config/publisher.yml` in `black knight`, which accepts a boolean value.
 
 Note: 
 - We can delay the load of the image generating script to increase LCP and load the placeholder for a particular interval.
-- If your app is cloned from `malibu-advanced`, pass `placeholder_delay` with the required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
+- If your app is cloned from `malibu-advanced`, pass `placeholder_delay` from `/app/config/publisher.yml` in `black knight` with the required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
 

--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -1,5 +1,5 @@
 ---
-title: Placeholder generation for hero image
+title: Placeholder generation for the hero image
 parent: Malibu Tutorial
 nav_order: 27
 nav_exclude: true
@@ -9,7 +9,7 @@ nav_exclude: true
 
 _This tutorial was contributed by [Harshith](https://www.linkedin.com/in/harshith-raj-092ba4176)_
 
-An image placeholder is a background-color over an empty space over which an actual image will be loaded.
+An image placeholder is a background color over the space, on which an actual image will be loaded.
 
 How Quintype handles image placeholder?
 
@@ -50,6 +50,6 @@ Eg:
 If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder from black knight `enable_placeholder` which accepts a boolean value.
 
 Note: 
-- We can delay the load of image generating script to increase lcp and load the placeholder for particular interval.
-- If your app is cloned from `malibu-advanced`, pass `placeholder_delay` with required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
+- We can delay the load of the image generating script to increase LCP and load the placeholder for a particular interval.
+- If your app is cloned from `malibu-advanced`, pass `placeholder_delay` with the required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
 

--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -47,7 +47,7 @@ Eg:
 }
 ```
 
-If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder from black knight `enable_placeholder` which accepts a boolean value.
+If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder from `black knight` `enable_placeholder` which accepts a boolean value.
 
 Note: 
 - We can delay the load of the image generating script to increase LCP and load the placeholder for a particular interval.

--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -47,9 +47,9 @@ Eg:
 }
 ```
 
-If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder, pass `enable_placeholder` from `/app/config/publisher.yml` in `black knight`, which accepts a boolean value.
+If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder, pass `enable_placeholder` from `/app/config/publisher.yml` in `black knight` under `publisher`, which accepts a boolean value.
 
 Note: 
 - We can delay the load of the image generating script to increase LCP and load the placeholder for a particular interval.
-- If your app is cloned from `malibu-advanced`, pass `placeholder_delay` from `/app/config/publisher.yml` in `black knight` with the required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
+- If your app is cloned from `malibu-advanced`, pass `placeholder_delay` from `/app/config/publisher.yml` in `black knight` under publisher with the required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
 

--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -50,6 +50,6 @@ Eg:
 If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder, pass `enable_placeholder` from `/app/config/publisher.yml` in `black knight` under `publisher`, which accepts a boolean value.
 
 Note: 
-- We can delay the load of the image generating script to increase LCP and load the placeholder for a particular interval.
+- We can delay the load of the image generating script to increase LCP and load the placeholder for a particular interval.(Doing this might have negative impact on SEO)
 - If your app is cloned from `malibu-advanced`, pass `placeholder_delay` from `/app/config/publisher.yml` in `black knight` under publisher with the required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
 

--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -25,7 +25,7 @@ Eg:
   ...
   ...
   />
- </figure>
+</figure>
 ```
 
 ```css

--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -14,7 +14,7 @@ An image placeholder is a background color over the space, on which an actual im
 How Quintype handles image placeholder?
 
 - Wrap `ResponsiveImage` component with `figure` tag.
-- Based on aspect ratio provide required `padding-top` to the `figure` tag using styleName/className.
+- Based on aspect ratio of the image provide `padding-top` to the `figure` tag using styleName/className.
 - Use a generic styleName/className to the `figure` tag to provide required `background- color`.
 
 Eg: 

--- a/tutorial/hero-image-placeholder.md
+++ b/tutorial/hero-image-placeholder.md
@@ -1,0 +1,55 @@
+---
+title: Placeholder generation for hero image
+parent: Malibu Tutorial
+nav_order: 27
+nav_exclude: true
+---
+
+# {{page.title}}
+
+_This tutorial was contributed by [Harshith](https://www.linkedin.com/in/harshith-raj-092ba4176)_
+
+An image placeholder is a background-color over an empty space over which an actual image will be loaded.
+
+How Quintype handles image placeholder?
+
+- Wrap `ResponsiveImage` component with `figure` tag.
+- Based on aspect ratio provide required `padding-top` to the `figure` tag using styleName/className.
+- Use a generic styleName/className to the `figure` tag to provide required `background- color`.
+
+Eg: 
+```javascript
+<figure className="qt-image-16x9" styleName="placeholder">
+  <ResponsiveImage
+  ...
+  ...
+  ...
+  />
+ </figure>
+```
+
+```css
+.qt-image-16x9 {
+  padding-top: 56.25%;
+  margin: 0;
+  position: relative;
+  overflow: hidden;
+
+  & img {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}
+
+.placeholder {
+  background-color: lightgrey;
+}
+```
+
+If your app is cloned from `malibu-advanced`, we provide a toggle to enable placeholder from black knight `enable_placeholder` which accepts a boolean value.
+
+Note: 
+- We can delay the load of image generating script to increase lcp and load the placeholder for particular interval.
+- If your app is cloned from `malibu-advanced`, pass `placeholder_delay` with required interval. Eg: `placeholder_delay: 3`, in this example there will be a delay of 3 seconds post that, we will be loading the required script.
+


### PR DESCRIPTION
# Description

this pr involves documentation for generating placeholder and delaying the load of script required to generate images

Fixes:
1. add a grey placeholder for the image background to improve UX. tix: https://github.com/quintype/ace-planning/issues/92
2. this helps if we want to delay a load of image generating script to improve score tix: https://github.com/quintype/ace-planning/issues/478
