### PR TITLE
bump components version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4200,19 +4200,21 @@
       }
     },
     "@quintype/components": {
-      "version": "2.31.3",
-      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-2.31.3.tgz",
-      "integrity": "sha512-plUetXVRDnhTO/+M8qEzrtclRZf/x0WFRJUp9qNr+qUHoEvyv9dZhaWfwn3EEr15smcA8q7iFJXad0POkgIWUg==",
+      "version": "2.31.7",
+      "resolved": "https://registry.npmjs.org/@quintype/components/-/components-2.31.7.tgz",
+      "integrity": "sha512-0h00GxXDbA3Bh8y66s6e6NaOxxg1r8/9cRnmAwtAEQYkuc+f7yxReiydBRrHofMvWCNjMJ2R/n6SNOOcj3Zycg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "atob": "^2.1.2",
         "classnames": "^2.2.6",
         "empty-web-gif": "^1.0.1",
+        "get-video-id": "^3.4.1",
         "get-youtube-id": "^1.0.1",
         "papaparse": "^5.2.0",
         "prop-types": "^15.7.2",
         "quintype-js": "^1.2.0",
         "react": "^16.8.6",
+        "react-dailymotion": "^0.4.1",
         "react-dfp": "github:quintype/react-dfp",
         "react-redux": "^7.0.3",
         "react-youtube": "^7.9.0",
@@ -11421,6 +11423,11 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "get-video-id": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-3.4.1.tgz",
+      "integrity": "sha512-2MkfbzofPQ7YsW0mrShmGEvnGrNzjXzAwJEePYwoi1dDqTpghHDMq5+T61Stmez8X4I+I8phT+unuttw/AB36w=="
+    },
     "get-youtube-id": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-youtube-id/-/get-youtube-id-1.0.1.tgz",
@@ -17792,6 +17799,11 @@
       "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
       "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
     },
+    "load-script2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/load-script2/-/load-script2-1.0.1.tgz",
+      "integrity": "sha512-36d/FxKtirfX9ALoQ+GXX4Hub+q3LdwFtgFXsj5Jc4TEfNPckDHN7YKCm0zTTnmcGHzjWlbHvIUb7+CtI7LFhA=="
+    },
     "load-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-source-map/-/load-source-map-2.0.0.tgz",
@@ -23648,6 +23660,15 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-dailymotion": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-dailymotion/-/react-dailymotion-0.4.1.tgz",
+      "integrity": "sha512-AlmeBV6ZtgO6aKojkt7Qc7IHSo4YdkvRwJPYcMwZZwKO6GvrmHhKg6DdG16L8dR9MyRUF1H6cPflKos82LfKnQ==",
+      "requires": {
+        "load-script2": "^1.0.1",
+        "prop-types": "^15.5.10"
       }
     },
     "react-dfp": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@loadable/component": "^5.14.1",
     "@loadable/server": "^5.14.2",
-    "@quintype/components": "^2.28.0",
+    "@quintype/components": "^2.31.7",
     "@quintype/framework": "^5.0.3",
     "@quintype/seo": "^1.38.29",
     "fontfaceobserver": "^2.1.0",


### PR DESCRIPTION
Vendor home list is quite huge in size which is throwing error under Reduce unused JavaScript in Page speed insights.
We need to reduce the vendor home list bundle size for getting rid of this error.
Ticket: quintype/ace-planning#542

Instead of calling the whole Proptypes , we replaced with the prop types which are need in the file. This change is done in quintype-node-components.
Removed importing of react in link.js file as its not used in it. This change is also done in quintype-node-components.